### PR TITLE
init necessary v1 address cache on startup.

### DIFF
--- a/Circles.Index.CirclesV1/LogParser.cs
+++ b/Circles.Index.CirclesV1/LogParser.cs
@@ -10,7 +10,7 @@ namespace Circles.Index.CirclesV1;
 
 public class LogParser(Address v1HubAddress) : ILogParser
 {
-    private static readonly ConcurrentDictionary<Address, object?> CirclesTokenAddresses = new();
+    public static readonly ConcurrentDictionary<Address, object?> CirclesTokenAddresses = new();
 
     private readonly Hash256 _transferTopic = new(DatabaseSchema.Transfer.Topic);
     private readonly Hash256 _signupTopic = new(DatabaseSchema.Signup.Topic);

--- a/Circles.Index.Common/DatabaseSchema.cs
+++ b/Circles.Index.Common/DatabaseSchema.cs
@@ -1,4 +1,9 @@
+using System.Text.Json;
+using Nethermind.Core;
+
 namespace Circles.Index.Common;
+
+public record BlockWithEventCounts(Block Block, IDictionary<string, int> EventCounts);
 
 public class DatabaseSchema : IDatabaseSchema
 {
@@ -13,8 +18,20 @@ public class DatabaseSchema : IDatabaseSchema
                 new EventSchema("System", "Block", new byte[32], [
                     new("blockNumber", ValueTypes.Int, false),
                     new("timestamp", ValueTypes.Int, true),
-                    new("blockHash", ValueTypes.String, false)
+                    new("blockHash", ValueTypes.String, false),
+                    new("eventCounts", ValueTypes.String, false)
                 ])
             }
         };
+
+    public DatabaseSchema()
+    {
+        SchemaPropertyMap.Add(("System", "Block"), new Dictionary<string, Func<BlockWithEventCounts, object?>>
+        {
+            { "blockNumber", o => o.Block.Number },
+            { "timestamp", o => (long)o.Block.Timestamp },
+            { "blockHash", o => o.Block.Hash!.ToString() },
+            { "eventCounts", o => JsonSerializer.Serialize(o.EventCounts) }
+        });
+    }
 }

--- a/Circles.Index.Query/Select.cs
+++ b/Circles.Index.Query/Select.cs
@@ -10,10 +10,9 @@ public record Select(
     IEnumerable<IFilterPredicate> Filter,
     IEnumerable<OrderBy> Order,
     int? Limit = null,
-    bool Distinct = false) : ISql
+    bool Distinct = false,
+    int MaxLimit = 1000) : ISql
 {
-    private const int MaxLimit = 1000;
-
     public ParameterizedSql ToSql(IDatabaseUtils database)
     {
         if (!database.Schema.Tables.TryGetValue((Namespace, Table), out var tableSchema))
@@ -74,7 +73,7 @@ public record Select(
             sql += orderBySql;
         }
 
-        if (Limit is > 0 and <= MaxLimit)
+        if (Limit > 0 && Limit <= MaxLimit)
         {
             sql += $" LIMIT {Limit.Value}";
         }

--- a/Circles.Index/BlockIndexer.cs
+++ b/Circles.Index/BlockIndexer.cs
@@ -15,7 +15,7 @@ public class ImportFlow(
 {
     private static readonly IndexPerformanceMetrics Metrics = new();
 
-    private readonly InsertBuffer<Block> _blockBuffer = new();
+    private readonly InsertBuffer<BlockWithEventCounts> _blockBuffer = new();
 
     private ExecutionDataflowBlockOptions CreateOptions(
         CancellationToken cancellationToken
@@ -32,12 +32,17 @@ public class ImportFlow(
 
     private async Task Sink((BlockWithReceipts, IEnumerable<IIndexEvent>) data)
     {
+        Dictionary<string, int> eventCounts = new();
+
         foreach (var indexEvent in data.Item2)
         {
             await context.Sink.AddEvent(indexEvent);
+            var tableName = context.Database.Schema.EventDtoTableMap.Map[indexEvent.GetType()];
+            var tableNameString = $"{tableName.Namespace}_{tableName.Table}";
+            eventCounts[tableNameString] = eventCounts.GetValueOrDefault(tableNameString) + 1;
         }
 
-        await AddBlock(data.Item1.Block);
+        await AddBlock(new BlockWithEventCounts(data.Item1.Block, eventCounts));
         Metrics.LogBlockWithReceipts(data.Item1);
     }
 
@@ -124,7 +129,7 @@ public class ImportFlow(
         };
     }
 
-    private async Task AddBlock(Block block)
+    private async Task AddBlock(BlockWithEventCounts block)
     {
         _blockBuffer.Add(block);
 
@@ -136,16 +141,16 @@ public class ImportFlow(
 
     public async Task FlushBlocks()
     {
-        var blocks = _blockBuffer.TakeSnapshot();
-
-        var map = new SchemaPropertyMap();
-        map.Add(("System", "Block"), new Dictionary<string, Func<Block, object?>>
+        try
         {
-            { "blockNumber", o => o.Number },
-            { "timestamp", o => (long)o.Timestamp },
-            { "blockHash", o => o.Hash!.ToString() }
-        });
-
-        await context.Sink.Database.WriteBatch("System", "Block", blocks, map);
+            var blocks = _blockBuffer.TakeSnapshot();
+            await context.Sink.Database.WriteBatch("System", "Block", blocks,
+                context.Database.Schema.SchemaPropertyMap);
+        }
+        catch (Exception e)
+        {
+            context.Logger.Error("Error flushing blocks", e);
+            throw;
+        }
     }
 }

--- a/Circles.Index/Circles.Index.csproj
+++ b/Circles.Index/Circles.Index.csproj
@@ -8,8 +8,8 @@
         <Authors>Daniel Janz (Gnosis Service GmbH)</Authors>
         <Copyright>Gnosis Service GmbH</Copyright>
         <Product>Circles</Product>
-        <AssemblyVersion>1.0</AssemblyVersion>
-        <FileVersion>1.0</FileVersion>
+        <AssemblyVersion>1.1</AssemblyVersion>
+        <FileVersion>1.1</FileVersion>
     </PropertyGroup>
 
 

--- a/Circles.Index/IndexPerformanceMetrics.cs
+++ b/Circles.Index/IndexPerformanceMetrics.cs
@@ -34,7 +34,7 @@ public class IndexPerformanceMetrics
                 "Logs/s:", metrics.LogsPerSecond, _totalLogs,
                 "MGas/s:", metrics.GasUsedPerSecond / 1000000, _totalGasUsed / 1000000L);
 
-            File.AppendAllLines("logs/circles-indexer.log", new[] { output });
+            // File.AppendAllLines("logs/circles-indexer.log", new[] { output });
 
             Console.WriteLine(output);
         }, null, TimeSpan.Zero, TimeSpan.FromSeconds(5));


### PR DESCRIPTION
don't output the connection string in the logs.
don't write performance logs to additional log file. write a block summary for each block.